### PR TITLE
Make giveable component require inventory

### DIFF
--- a/src/Lib/Diagnostics/BehaviorPack/Entity/components/dependencies.ts
+++ b/src/Lib/Diagnostics/BehaviorPack/Entity/components/dependencies.ts
@@ -28,6 +28,9 @@ const component_dependents_any: DependedMap = {
     "minecraft:behavior.nearest_attackable_target",
     "minecraft:behavior.hurt_by_target",
   ],
+  "minecraft:giveable": [
+    "minecraft:inventory",
+  ],
 };
 
 /**Checks if components dependencies are present, a component might need others to be present


### PR DESCRIPTION
While experimenting with giveable component, I noticed, that without an inventory component, it would not trigger the event.