### PR TITLE
Add checks for icon and material instance referring to valid atlas textures

### DIFF
--- a/src/Lib/Diagnostics/BehaviorPack/Block/components/diagnose.ts
+++ b/src/Lib/Diagnostics/BehaviorPack/Block/components/diagnose.ts
@@ -86,6 +86,16 @@ const component_test: Record<string, ComponentCheck> = {
   "minecraft:loot": (name, component, context, diagnoser) => {
     if (typeof component === "string") behaviorpack_loot_table_diagnose(component, diagnoser);
   },
+  "minecraft:material_instances": (name, component, context, diagnoser) => {
+    Object.keys(component).forEach(value => {
+      const textureId = component[value].texture;
+      if (!diagnoser.context.getCache().resourcePacks.textures.find(val => val.id == textureId && val.location.uri.includes('terrain_texture')))
+        diagnoser.add(textureId,
+          `Texture reference "${textureId}" was not defined in terrain_texture.json`,
+          DiagnosticSeverity.error,
+          'behaviorpack.block.components.texture_not_found')
+    })
+  }
 };
 
 function deprecated_component(replacement?: string) {

--- a/src/Lib/Diagnostics/BehaviorPack/Item/components/diagnose.ts
+++ b/src/Lib/Diagnostics/BehaviorPack/Item/components/diagnose.ts
@@ -1,5 +1,5 @@
 import { ComponentBehavior } from "bc-minecraft-bedrock-types/lib/minecraft/components";
-import { DocumentDiagnosticsBuilder } from "../../../../Types";
+import { DiagnosticSeverity, DocumentDiagnosticsBuilder } from "../../../../Types";
 import { Context } from "../../../../utility/components";
 import { component_error, ComponentCheck, components_check } from "../../../../utility/components/checks";
 import { behaviorpack_check_blockid } from "../../Block";
@@ -49,12 +49,12 @@ const component_test: Record<string, ComponentCheck> = {
     if (Array.isArray(component.dispense_on))
       component.dispense_on.forEach((block: string | { name: string }) => {
         if (typeof block == 'object' && 'name' in block) behaviorpack_check_blockid(block.name, diagnoser)
-          else if (typeof block == 'string') behaviorpack_check_blockid(block, diagnoser);
+        else if (typeof block == 'string') behaviorpack_check_blockid(block, diagnoser);
       });
     if (Array.isArray(component.use_on))
       component.use_on.forEach((block: string | { name: string }) => {
         if (typeof block == 'object' && 'name' in block) behaviorpack_check_blockid(block.name, diagnoser)
-          else if (typeof block == 'string') behaviorpack_check_blockid(block, diagnoser);
+        else if (typeof block == 'string') behaviorpack_check_blockid(block, diagnoser);
       });
     if (component.entity) behaviorpack_entityid_diagnose(component.entity, diagnoser);
   },
@@ -62,11 +62,11 @@ const component_test: Record<string, ComponentCheck> = {
     if (Array.isArray(component.use_on))
       component.use_on.forEach((block: string | { name: string }) => {
         if (typeof block == 'object' && 'name' in block) behaviorpack_check_blockid(block.name, diagnoser)
-          else if (typeof block == 'string') behaviorpack_check_blockid(block, diagnoser);
+        else if (typeof block == 'string') behaviorpack_check_blockid(block, diagnoser);
       });
     if (component.block) {
       if (typeof component.block == 'object' && 'name' in component.block) behaviorpack_check_blockid((component.block as { name: string }).name, diagnoser)
-        else if (typeof component.block == 'string') behaviorpack_check_blockid(component.block, diagnoser);
+      else if (typeof component.block == 'string') behaviorpack_check_blockid(component.block, diagnoser);
     }
   },
   "minecraft:projectile": (name, component, context, diagnoser) => {
@@ -81,7 +81,25 @@ const component_test: Record<string, ComponentCheck> = {
           });
       });
   },
-  // TODO: Check if icon points to valid item_texture
+  "minecraft:icon": (name, component, context, diagnoser) => {
+    if (typeof component == 'string') {
+      const textureId = component
+      if (!diagnoser.context.getCache().resourcePacks.textures.find(val => val.id == textureId && val.location.uri.includes('item_texture')))
+        diagnoser.add(textureId,
+          `Texture reference "${textureId}" was not defined in item_texture.json`,
+          DiagnosticSeverity.error,
+          'behaviorpack.item.components.texture_not_found')
+    } else {
+      Object.keys(component.textures)?.forEach(value => {
+        const textureId = component.textures[value];
+        if (!diagnoser.context.getCache().resourcePacks.textures.find(val => val.id == textureId && val.location.uri.includes('item_texture')))
+          diagnoser.add(textureId,
+            `Texture reference "${textureId}" was not defined in item_texture.json`,
+            DiagnosticSeverity.error,
+            'behaviorpack.item.components.texture_not_found')
+      })
+    }
+  }
 };
 
 function deprecated_component(replacement?: string) {


### PR DESCRIPTION
Resolve #208 
Resolve #165 

Idk if I setup something wrong but sometimes when loading the folder, it'd initially throw an error saying none of the item textures were recognized but then clicking on the files instantly resolved them.

Also, I'm not sure but I think if `item_texture.json` and `terrain_texture.json` both have textures references with the same key then only one of them is being saved into the cache.

```json
{
	"resource_pack_name": "rp",
	"texture_name": "atlas.items",
	"texture_data": {
		"a": {
			"textures": "textures/items/a"
		}
	}
```

```json
{
	"resource_pack_name": "rp",
	"texture_name": "atlas.terrain",
	"padding": 8,
	"num_mip_levels": 4,
	"texture_data": {
		"a": {
			"textures": "textures/blocks/a"
		}
	}
```