### PR TITLE
Update diagnoser for separated atlas textures

### DIFF
--- a/src/Lib/Diagnostics/BehaviorPack/Block/components/diagnose.ts
+++ b/src/Lib/Diagnostics/BehaviorPack/Block/components/diagnose.ts
@@ -89,7 +89,7 @@ const component_test: Record<string, ComponentCheck> = {
   "minecraft:material_instances": (name, component, context, diagnoser) => {
     Object.keys(component).forEach(value => {
       const textureId = component[value].texture;
-      if (!diagnoser.context.getCache().resourcePacks.textures.find(val => val.id == textureId && val.location.uri.includes('terrain_texture')))
+      if (!diagnoser.context.getCache().resourcePacks.terrainTextures.find(val => val.id == textureId))
         diagnoser.add(textureId,
           `Texture reference "${textureId}" was not defined in terrain_texture.json`,
           DiagnosticSeverity.error,

--- a/src/Lib/Diagnostics/BehaviorPack/Item/components/diagnose.ts
+++ b/src/Lib/Diagnostics/BehaviorPack/Item/components/diagnose.ts
@@ -84,7 +84,7 @@ const component_test: Record<string, ComponentCheck> = {
   "minecraft:icon": (name, component, context, diagnoser) => {
     if (typeof component == 'string') {
       const textureId = component
-      if (!diagnoser.context.getCache().resourcePacks.textures.find(val => val.id == textureId && val.location.uri.includes('item_texture')))
+      if (!diagnoser.context.getCache().resourcePacks.itemTextures.find(val => val.id == textureId))
         diagnoser.add(textureId,
           `Texture reference "${textureId}" was not defined in item_texture.json`,
           DiagnosticSeverity.error,
@@ -92,7 +92,7 @@ const component_test: Record<string, ComponentCheck> = {
     } else {
       Object.keys(component.textures)?.forEach(value => {
         const textureId = component.textures[value];
-        if (!diagnoser.context.getCache().resourcePacks.textures.find(val => val.id == textureId && val.location.uri.includes('item_texture')))
+        if (!diagnoser.context.getCache().resourcePacks.itemTextures.find(val => val.id == textureId))
           diagnoser.add(textureId,
             `Texture reference "${textureId}" was not defined in item_texture.json`,
             DiagnosticSeverity.error,

--- a/src/Lib/Diagnostics/ResourcePack/Block/entry.ts
+++ b/src/Lib/Diagnostics/ResourcePack/Block/entry.ts
@@ -39,7 +39,7 @@ export function Diagnose(diagnoser: DocumentDiagnosticsBuilder): void {
 }
 
 function hasDefinition(block: string, value: string, rp: ResourcePackCollection, diagnoser: DiagnosticsBuilder): void {
-  if (rp.textures.has(value)) return;
+  if (rp.terrainTextures.has(value)) return;
 
   diagnoser.add(
     `${block}/${value}`,


### PR DESCRIPTION
Didn't see any other uses of `resourcepack.textures`