### PR TITLE
Update item component validation

### DIFF
--- a/src/Lib/Diagnostics/BehaviorPack/Item/components/diagnose.ts
+++ b/src/Lib/Diagnostics/BehaviorPack/Item/components/diagnose.ts
@@ -113,6 +113,7 @@ const component_test: Record<string, ComponentCheck<Internal.BehaviorPack.Item>>
       `To use custom components, a minimum format version of 1.21.10 is required`,
       DiagnosticSeverity.error,
       'behaviorpack.item.components.custom_components_min_version')
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
   } catch (err) {
     // Leaving this empty as the base diagnoser should already flag an invalid format version
   }

--- a/src/Lib/Diagnostics/BehaviorPack/Item/components/diagnose.ts
+++ b/src/Lib/Diagnostics/BehaviorPack/Item/components/diagnose.ts
@@ -7,6 +7,7 @@ import { minecraft_get_item } from "../../../Minecraft/Items";
 import { behaviorpack_check_blockid } from "../../Block";
 import { behaviorpack_entityid_diagnose } from "../../Entity";
 import { behaviorpack_item_diagnose } from "../diagnose";
+import { FormatVersion } from 'bc-minecraft-bedrock-types/lib/minecraft';
 
 /**
  *
@@ -65,6 +66,10 @@ const component_test: Record<string, ComponentCheck<Internal.BehaviorPack.Item>>
         if (typeof block == 'object' && 'name' in block) behaviorpack_check_blockid(block.name, diagnoser)
         else if (typeof block == 'string') behaviorpack_check_blockid(block, diagnoser);
       });
+    if (component.replace_block_item && context.source['minecraft:item'].description.identifier != component.block) diagnoser.add(`minecraft:block_placer/block/${component.block}`,
+      `${component.replace_block_item} and ${context.source['minecraft:item'].description.identifier} need to match when trying to replace the block item`,
+      DiagnosticSeverity.error,
+      'behaviorpack.item.components.replace_block_ids_dont_match') 
     if (component.block) {
       if (typeof component.block == 'object' && 'name' in component.block) behaviorpack_check_blockid((component.block as { name: string }).name, diagnoser)
       else if (typeof component.block == 'string') behaviorpack_check_blockid(component.block, diagnoser);
@@ -100,6 +105,17 @@ const component_test: Record<string, ComponentCheck<Internal.BehaviorPack.Item>>
             'behaviorpack.item.components.texture_not_found')
       })
     }
+  },
+  "minecraft:custom_components": (name, component, context, diagnoser) => {
+  try {
+    const version = FormatVersion.parse(context.source.format_version);
+    if (version[0] < 1 || version[1] < 21 || (version[2] < 10 && version[1] <= 21)) diagnoser.add(context.source.format_version,
+      `To use custom components, a minimum format version of 1.21.10 is required`,
+      DiagnosticSeverity.error,
+      'behaviorpack.item.components.custom_components_min_version')
+  } catch (err) {
+    // Leaving this empty as the base diagnoser should already flag an invalid format version
+  }
   }
 };
 


### PR DESCRIPTION
Resolve #282 
And includes a check for custom components using a format version lower than 1.21.10