### PR TITLE
Only check vanilla controllers if they are being used

### DIFF
--- a/src/lib/diagnostics/minecraft/animation.ts
+++ b/src/lib/diagnostics/minecraft/animation.ts
@@ -33,10 +33,13 @@ export function minecraft_animation_used(
   const refsUsed: Record<string, boolean> = {};
   const { animation_controllers, animations, script } = data;
 
+  const controllersUsed = Object.values(animation_controllers).concat(Object.values(animations)).filter(id => id.startsWith('controller.'))
+
   // Check against vanilla controllers
-  Vanilla.ResourcePack.AnimationControllers.forEach((controller) =>
+  Vanilla.ResourcePack.AnimationControllers.forEach((controller) => {
+    if (!controllersUsed.includes(controller.id)) return;
     controller.animations.forEach((anim) => (refsUsed[anim] = true))
-  );
+  });
 
   // Animations field is to be used by script and animations controllers
   Types.Definition.forEach(animations, (ref, id) => {


### PR DESCRIPTION
```json
"animations": {
    "shoot": "animation.name.shoot"
}
```

Gets marked as used despite it not actually being used. This fixes that