### PR TITLE
Add spawn rule checking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2194,9 +2194,9 @@
       }
     },
     "node_modules/bc-minecraft-bedrock-project": {
-      "version": "1.21.100-0",
-      "resolved": "https://registry.npmjs.org/bc-minecraft-bedrock-project/-/bc-minecraft-bedrock-project-1.21.100-0.tgz",
-      "integrity": "sha512-PshyVuESPoLolAYseiDBF8mv/9QZKfjrvBQ9XZvygScxSx/y27S3gkfOPb+g2moGH3rJO1R6trd7dYMHyE73/w==",
+      "version": "1.21.100-1",
+      "resolved": "https://registry.npmjs.org/bc-minecraft-bedrock-project/-/bc-minecraft-bedrock-project-1.21.100-1.tgz",
+      "integrity": "sha512-6bhbNex3+W2h+4XlYXyUyzGif5+bd7mlDblaQigtodVV3Uhb+ZsadXIfIu/nS59cCBnoGk8yMs6aFhlWf7eF2g==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bc-minecraft-bedrock-command": "^1.21.100-0",

--- a/src/lib/diagnostics/behavior-pack/spawn-rule/components/diagnose.ts
+++ b/src/lib/diagnostics/behavior-pack/spawn-rule/components/diagnose.ts
@@ -1,0 +1,68 @@
+import { Internal } from "bc-minecraft-bedrock-project";
+import { ComponentBehavior } from "bc-minecraft-bedrock-types/lib/minecraft/components";
+import { DocumentDiagnosticsBuilder } from "../../../../types";
+import { Context } from "../../../../utility/components";
+import { ComponentCheck, components_check } from "../../../../utility/components/checks";
+import { minecraft_diagnose_filters } from '../../../minecraft/filter';
+import { behaviorpack_entity_event_diagnose, behaviorpack_entityid_diagnose } from '../../entity';
+import { is_block_defined } from '../../block';
+
+/**
+ *
+ * @param container
+ * @param context
+ * @param diagnoser
+ */
+export function behaviorpack_diagnose_spawnrule_components(
+  container: ComponentBehavior,
+  context: Context<Internal.BehaviorPack.SpawnRule>,
+  diagnoser: DocumentDiagnosticsBuilder
+): void {
+  components_check(container, context, diagnoser, component_test);
+}
+
+const component_test: Record<string, ComponentCheck<Internal.BehaviorPack.SpawnRule>> = {
+  "minecraft:biome_filter": (name, component, context, diagnoser) => {
+    minecraft_diagnose_filters(component, diagnoser)
+  },
+  "minecraft:delay_filter": (name, component, context, diagnoser) => {
+    if (typeof component.identifier == 'string') behaviorpack_entityid_diagnose(component.identifier, diagnoser)
+  },
+  "minecraft:herd": (name, component, context, diagnoser) => {
+    const entity = diagnoser.context.getProjectData().projectData.behaviorPacks.entities.get(context.source['minecraft:spawn_rules'].description.identifier)
+    if (!entity) return;
+    if (typeof component.event == 'string') behaviorpack_entity_event_diagnose(component.event, name, entity.events, diagnoser)
+  },
+  "minecraft:permute_type": (name, component, context, diagnoser) => {
+    processEntries(component, (entry: any) => {
+      if (typeof entry.entity_type == 'string') behaviorpack_entityid_diagnose(entry.entity_type, diagnoser)
+    })
+  },
+  "minecraft:spawn_event": (name, component, context, diagnoser) => {
+    const entity = diagnoser.context.getProjectData().projectData.behaviorPacks.entities.get(context.source['minecraft:spawn_rules'].description.identifier)
+    if (!entity) return;
+    if (typeof component.event == 'string') behaviorpack_entity_event_diagnose(component.event, name, entity.events, diagnoser)
+  },
+  "minecraft:spawns_on_block_filter": (name, component, context, diagnoser) => {
+    if (typeof component == 'string') is_block_defined(component, diagnoser);
+    else if (Array.isArray(component)) component.forEach(entry => {
+      if (typeof entry == 'string') is_block_defined(entry, diagnoser);
+      else if (typeof entry == 'object' && typeof entry.name == 'string') is_block_defined(entry.name, diagnoser)
+    })
+    else if (typeof component == 'object' && typeof component.name == 'string') is_block_defined(component.name, diagnoser)
+  },
+  "minecraft:spawns_on_block_prevented_filter": (name, component, context, diagnoser) => {
+    if (typeof component == 'string') is_block_defined(component, diagnoser);
+    else if (Array.isArray(component)) component.forEach(entry => {
+      if (typeof entry == 'string') is_block_defined(entry, diagnoser);
+      else if (typeof entry == 'object' && typeof entry.name == 'string') is_block_defined(entry.name, diagnoser)
+    })
+    else if (typeof component == 'object' && typeof component.name == 'string') is_block_defined(component.name, diagnoser)
+  }
+};
+
+//! Move into some util place as this function is duplicated in entity/components/diagnose.ts
+function processEntries<T>(data: T | T[], callback: (entry: T) => void) {
+  if (Array.isArray(data)) data.forEach(callback);
+  else if (data) callback(data);
+}

--- a/src/lib/diagnostics/behavior-pack/spawn-rule/components/index.ts
+++ b/src/lib/diagnostics/behavior-pack/spawn-rule/components/index.ts
@@ -1,0 +1,3 @@
+/*	Auto generated	*/
+
+export * from "./diagnose";

--- a/src/lib/diagnostics/behavior-pack/spawn-rule/entry.ts
+++ b/src/lib/diagnostics/behavior-pack/spawn-rule/entry.ts
@@ -1,5 +1,9 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
+import { Internal } from 'bc-minecraft-bedrock-project';
+import { Json } from '../../json';
 import { DocumentDiagnosticsBuilder } from "../../../types";
+import { behaviorpack_entityid_diagnose } from '../entity';
+import { Context } from "../../../utility/components";
+import { behaviorpack_diagnose_spawnrule_components } from './components';
 
 /**
  * Diagnoses the given document as an spawn rule
@@ -7,5 +11,24 @@ import { DocumentDiagnosticsBuilder } from "../../../types";
  * @param diagnoser The diagnoser builder to receive the errors
  */
 export function diagnose_spawn_rule_document(diagnoser: DocumentDiagnosticsBuilder): void {
-  //TODO add diagnostics
+  const rule = Json.LoadReport<Internal.BehaviorPack.SpawnRule>(diagnoser);
+  if (!Internal.BehaviorPack.SpawnRule.is(rule)) return;
+
+  behaviorpack_entityid_diagnose(rule['minecraft:spawn_rules'].description.identifier, diagnoser);
+
+  rule['minecraft:spawn_rules'].conditions.forEach(data => {
+    const out: string[] = [];
+
+    Object.getOwnPropertyNames(data).forEach((c) => {
+      if (!out.includes(c)) out.push(c);
+    });
+
+    const context: Context<Internal.BehaviorPack.SpawnRule> = {
+      source: rule,
+      components: out,
+    };
+
+    behaviorpack_diagnose_spawnrule_components(data, context, diagnoser);
+  })
+
 }


### PR DESCRIPTION
I've left a todo in the file for you since I figured that type of thing is best left up to you.

On a similar note, the `deprecated_component()` func exists in the block/item/entity components each individually with slight variation. So, that could also be adjusted.